### PR TITLE
Extend 0.39.1 with Dencun opcodes

### DIFF
--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -156,6 +156,10 @@ fn eval_mstore8(state: &mut Machine, _opcode: Opcode, _position: usize) -> Contr
 	self::misc::mstore8(state)
 }
 
+fn eval_mcopy(state: &mut Machine, _opcode: Opcode, _position: usize) -> Control {
+	self::misc::mcopy(state)
+}
+
 fn eval_jump(state: &mut Machine, _opcode: Opcode, _position: usize) -> Control {
 	self::misc::jump(state)
 }
@@ -492,6 +496,7 @@ pub fn eval(state: &mut Machine, opcode: Opcode, position: usize) -> Control {
 		table[Opcode::MLOAD.as_usize()] = eval_mload as _;
 		table[Opcode::MSTORE.as_usize()] = eval_mstore as _;
 		table[Opcode::MSTORE8.as_usize()] = eval_mstore8 as _;
+		table[Opcode::MCOPY.as_usize()] = eval_mcopy as _;
 		table[Opcode::JUMP.as_usize()] = eval_jump as _;
 		table[Opcode::JUMPI.as_usize()] = eval_jumpi as _;
 		table[Opcode::PC.as_usize()] = eval_pc as _;

--- a/core/src/opcode.rs
+++ b/core/src/opcode.rs
@@ -227,6 +227,10 @@ impl Opcode {
 	pub const SLOAD: Opcode = Opcode(0x54);
 	/// `SSTORE`
 	pub const SSTORE: Opcode = Opcode(0x55);
+	/// `TLOAD`
+	pub const TLOAD: Opcode = Opcode(0x5c);
+	/// `TSTORE`
+	pub const TSTORE: Opcode = Opcode(0x5d);
 	/// `GAS`
 	pub const GAS: Opcode = Opcode(0x5a);
 	/// `LOGn`

--- a/core/src/opcode.rs
+++ b/core/src/opcode.rs
@@ -83,6 +83,8 @@ impl Opcode {
 	pub const MSTORE: Opcode = Opcode(0x52);
 	/// `MSTORE8`
 	pub const MSTORE8: Opcode = Opcode(0x53);
+	/// `MCOPY`
+	pub const MCOPY: Opcode = Opcode(0x5e);
 	/// `JUMP`
 	pub const JUMP: Opcode = Opcode(0x56);
 	/// `JUMPI`

--- a/core/src/opcode.rs
+++ b/core/src/opcode.rs
@@ -189,6 +189,8 @@ impl Opcode {
 	pub const SELFBALANCE: Opcode = Opcode(0x47);
 	/// `BASEFEE`
 	pub const BASEFEE: Opcode = Opcode(0x48);
+	/// `BLOBBASEFEE`
+	pub const BLOBBASEFEE: Opcode = Opcode(0x4a);
 	/// `ORIGIN`
 	pub const ORIGIN: Opcode = Opcode(0x32);
 	/// `CALLER`

--- a/runtime/src/eval/mod.rs
+++ b/runtime/src/eval/mod.rs
@@ -44,6 +44,8 @@ pub fn eval<H: Handler>(state: &mut Runtime, opcode: Opcode, handler: &mut H) ->
 		Opcode::GASLIMIT => system::gaslimit(state, handler),
 		Opcode::SLOAD => system::sload(state, handler),
 		Opcode::SSTORE => system::sstore(state, handler),
+		Opcode::TLOAD => system::tload(state, handler),
+		Opcode::TSTORE => system::tstore(state, handler),
 		Opcode::GAS => system::gas(state, handler),
 		Opcode::LOG0 => system::log(state, 0, handler),
 		Opcode::LOG1 => system::log(state, 1, handler),

--- a/runtime/src/eval/mod.rs
+++ b/runtime/src/eval/mod.rs
@@ -59,6 +59,7 @@ pub fn eval<H: Handler>(state: &mut Runtime, opcode: Opcode, handler: &mut H) ->
 		Opcode::STATICCALL => system::call(state, CallScheme::StaticCall, handler),
 		Opcode::CHAINID => system::chainid(state, handler),
 		Opcode::BASEFEE => system::base_fee(state, handler),
+		Opcode::BLOBBASEFEE => system::blob_base_fee(state, handler),
 		_ => handle_other(state, opcode, handler),
 	}
 }

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -236,6 +236,27 @@ pub fn sstore<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> 
 	}
 }
 
+pub fn tload<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
+	pop!(runtime, index);
+	let value = handler.transient_storage(index);
+	push!(runtime, value);
+
+	event!(TLoad { index, value });
+
+	Control::Continue
+}
+
+pub fn tstore<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
+	pop!(runtime, index, value);
+
+	event!(TStore { index, value });
+
+	match handler.set_transient_storage(index, value) {
+		Ok(()) => Control::Continue,
+		Err(e) => Control::Exit(e.into()),
+	}
+}
+
 pub fn gas<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	push_u256!(runtime, handler.gas_left());
 

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -90,6 +90,14 @@ pub fn base_fee<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	Control::Continue
 }
 
+pub fn blob_base_fee<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
+	let mut ret = H256::default();
+	handler.block_blob_base_fee().to_big_endian(&mut ret[..]);
+	push!(runtime, ret);
+
+	Control::Continue
+}
+
 pub fn extcodesize<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop!(runtime, address);
 	push_u256!(runtime, handler.code_size(address.into()));

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -60,6 +60,8 @@ pub trait Handler {
 	fn block_gas_limit(&self) -> U256;
 	/// Environmental block base fee.
 	fn block_base_fee_per_gas(&self) -> U256;
+	/// Returns the value of the blob base-fee of the current block it is executing in.
+	fn block_blob_base_fee(&self) -> U256;
 	/// Get environmental chain ID.
 	fn chain_id(&self) -> U256;
 

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -35,6 +35,8 @@ pub trait Handler {
 	fn code(&self, address: H160) -> Vec<u8>;
 	/// Get storage value of address at index.
 	fn storage(&self, address: H160, index: H256) -> H256;
+	/// Get transient storage value at index.
+	fn transient_storage(&self, index: H256) -> H256;
 	/// Get original storage value of address at index.
 	fn original_storage(&self, address: H160, index: H256) -> H256;
 
@@ -79,6 +81,8 @@ pub trait Handler {
 
 	/// Set storage value of address at index.
 	fn set_storage(&mut self, address: H160, index: H256, value: H256) -> Result<(), ExitError>;
+	/// Set transient storage value at index.
+	fn set_transient_storage(&mut self, index: H256, value: H256) -> Result<(), ExitError>;
 	/// Create a log owned by address with given topics and data.
 	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) -> Result<(), ExitError>;
 	/// Mark an address to be deleted, with funds transferred to target.

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -32,6 +32,14 @@ pub enum Event<'a> {
 		index: H256,
 		value: H256,
 	},
+	TLoad {
+		index: H256,
+		value: H256,
+	},
+	TStore {
+		index: H256,
+		value: H256,
+	},
 }
 
 // Expose `listener::with` to the crate only.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.68.2"
+channel = "1.70.0"
 profile = "minimal"
-components = [ "rustfmt", "clippy" ]
+components = ["rustfmt", "clippy"]

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -31,6 +31,8 @@ pub struct MemoryVicinity {
 	pub block_gas_limit: U256,
 	/// Environmental base fee per gas.
 	pub block_base_fee_per_gas: U256,
+	/// Environmental blob base fee.
+	pub block_blob_base_fee: U256,
 	/// Environmental randomness.
 	///
 	/// In Ethereum, this is the randomness beacon provided by the beacon
@@ -123,6 +125,10 @@ impl<'vicinity> Backend for MemoryBackend<'vicinity> {
 	}
 	fn block_base_fee_per_gas(&self) -> U256 {
 		self.vicinity.block_base_fee_per_gas
+	}
+
+	fn block_blob_base_fee(&self) -> U256 {
+		self.vicinity.block_blob_base_fee
 	}
 
 	fn chain_id(&self) -> U256 {

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -63,15 +63,21 @@ pub struct MemoryAccount {
 pub struct MemoryBackend<'vicinity> {
 	vicinity: &'vicinity MemoryVicinity,
 	state: BTreeMap<H160, MemoryAccount>,
+	transient_state: BTreeMap<H256, H256>,
 	logs: Vec<Log>,
 }
 
 impl<'vicinity> MemoryBackend<'vicinity> {
 	/// Create a new memory backend.
-	pub fn new(vicinity: &'vicinity MemoryVicinity, state: BTreeMap<H160, MemoryAccount>) -> Self {
+	pub fn new(
+		vicinity: &'vicinity MemoryVicinity,
+		state: BTreeMap<H160, MemoryAccount>,
+		transient_state: BTreeMap<H256, H256>,
+	) -> Self {
 		Self {
 			vicinity,
 			state,
+			transient_state,
 			logs: Vec::new(),
 		}
 	}
@@ -160,6 +166,13 @@ impl<'vicinity> Backend for MemoryBackend<'vicinity> {
 		self.state
 			.get(&address)
 			.map(|v| v.storage.get(&index).cloned().unwrap_or_default())
+			.unwrap_or_default()
+	}
+
+	fn transient_storage(&self, index: H256) -> H256 {
+		self.transient_state
+			.get(&index)
+			.cloned()
 			.unwrap_or_default()
 	}
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -72,6 +72,8 @@ pub trait Backend {
 	fn block_gas_limit(&self) -> U256;
 	/// Environmental block base fee.
 	fn block_base_fee_per_gas(&self) -> U256;
+	/// Returns the value of the blob base-fee of the current block it is executing in.
+	fn block_blob_base_fee(&self) -> U256;
 	/// Environmental chain ID.
 	fn chain_id(&self) -> U256;
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -85,6 +85,8 @@ pub trait Backend {
 	fn code(&self, address: H160) -> Vec<u8>;
 	/// Get storage value of address at index.
 	fn storage(&self, address: H160, index: H256) -> H256;
+	/// Get storage value at index.
+	fn transient_storage(&self, index: H256) -> H256;
 	/// Get original storage value of address at index, if available.
 	fn original_storage(&self, address: H160, index: H256) -> Option<H256>;
 }

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -206,6 +206,7 @@ pub trait StackState<'config>: Backend {
 
 	fn inc_nonce(&mut self, address: H160) -> Result<(), ExitError>;
 	fn set_storage(&mut self, address: H160, key: H256, value: H256);
+	fn set_transient_storage(&mut self, key: H256, value: H256);
 	fn reset_storage(&mut self, address: H160);
 	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>);
 	fn set_deleted(&mut self, address: H160);
@@ -1047,6 +1048,10 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Handler
 		self.state.storage(address, index)
 	}
 
+	fn transient_storage(&self, index: H256) -> H256 {
+		self.state.transient_storage(index)
+	}
+
 	fn original_storage(&self, address: H160, index: H256) -> H256 {
 		self.state
 			.original_storage(address, index)
@@ -1134,6 +1139,11 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Handler
 
 	fn set_storage(&mut self, address: H160, index: H256, value: H256) -> Result<(), ExitError> {
 		self.state.set_storage(address, index, value);
+		Ok(())
+	}
+
+	fn set_transient_storage(&mut self, index: H256, value: H256) -> Result<(), ExitError> {
+		self.state.set_transient_storage(index, value);
 		Ok(())
 	}
 

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1121,6 +1121,9 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Handler
 	fn block_base_fee_per_gas(&self) -> U256 {
 		self.state.block_base_fee_per_gas()
 	}
+	fn block_blob_base_fee(&self) -> U256 {
+		self.state.block_blob_base_fee()
+	}
 	fn chain_id(&self) -> U256 {
 		self.state.chain_id()
 	}

--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -435,6 +435,9 @@ impl<'backend, 'config, B: Backend> Backend for MemoryStackState<'backend, 'conf
 	fn block_base_fee_per_gas(&self) -> U256 {
 		self.backend.block_base_fee_per_gas()
 	}
+	fn block_blob_base_fee(&self) -> U256 {
+		self.backend.block_blob_base_fee()
+	}
 
 	fn chain_id(&self) -> U256 {
 		self.backend.chain_id()


### PR DESCRIPTION
**Meta-MR**, doesn't need to be merged whatsoever, purely to see the diffs between version `0.39.1` and the _hack-ish_ implementation of Dencun's opcodes.